### PR TITLE
Update graph.py

### DIFF
--- a/csrgraph/graph.py
+++ b/csrgraph/graph.py
@@ -3,7 +3,7 @@ from copy import deepcopy
 import gc
 import networkx as nx
 import numba
-from numba import jit, jitclass
+from numba import jit
 import numpy as np
 import os
 import pandas as pd


### PR DESCRIPTION
JitClass is not used also it has been moved to numba.experimental so can we remove this from code and update the package
https://github.com/numba/numba/issues/6539