### PR TITLE
Add functionality for loading a CSRGraph from an in-memory set of edges

### DIFF
--- a/csrgraph/graph.py
+++ b/csrgraph/graph.py
@@ -21,6 +21,12 @@ from csrgraph.random_walks import (
 from csrgraph import methods, random_walks
 from csrgraph import ggvec, glove, grarep
 
+__all__ = [
+    "csrgraph",
+    "read_edgelist",
+    "from_tuples",
+]
+
 UINT32_MAX = (2**32) - 1
 UINT16_MAX = (2**16) - 1
 
@@ -477,7 +483,7 @@ class csrgraph():
 
 def read_edgelist(f, directed=True, sep=r"\s+", header=None, keep_default_na=False, **readcsvkwargs):
     """
-    Creates a csrgraph from an edgelist.
+    Creates a csrgraph from an edgelist file.
 
     The edgelist should be in the form 
        [source  destination]
@@ -571,3 +577,16 @@ def _from_df(elist: pd.DataFrame, directed: bool = True) -> csrgraph:
         nnodes, nodenames=names
     )
     return G
+
+
+def from_tuples(tuples, directed: bool = False) -> csrgraph:
+    """
+    Creates a csrgraph from an iterable of edge tuples.
+
+    tuples : iterable[tuple[str, str]] or iterable[tuple[str, str, str]]]
+        Either an iterable of source, target pairs or an iterable of
+        source, target, weight triples
+    Returns : csrgraph
+    """
+    elist = pd.DataFrame(tuples)
+    return _from_df(elist, directed=directed)

--- a/csrgraph/graph.py
+++ b/csrgraph/graph.py
@@ -24,6 +24,7 @@ from csrgraph import ggvec, glove, grarep
 __all__ = [
     "csrgraph",
     "read_edgelist",
+    "from_df",
     "from_tuples",
 ]
 
@@ -515,10 +516,18 @@ def read_edgelist(f, directed=True, sep=r"\s+", header=None, keep_default_na=Fal
         f, sep=sep, header=header, 
         keep_default_na=keep_default_na, **readcsvkwargs
     )
-    return _from_df(elist, directed=directed)
+    return from_df(elist, directed=directed)
 
 
-def _from_df(elist: pd.DataFrame, directed: bool = True) -> csrgraph:
+def from_df(elist: pd.DataFrame, directed: bool = True) -> csrgraph:
+    """
+    Creates a csrgraph from a DataFrame of either two or three columns.
+
+    elist :
+        Either a DataFrame with two columns for source and target or three
+        columns for source, target, and weight.
+    Returns : csrgraph
+    """
     if len(elist.columns) == 2:
         elist.columns = ['src', 'dst']
         elist['weight'] = np.ones(elist.shape[0])
@@ -589,4 +598,4 @@ def from_tuples(tuples, directed: bool = False) -> csrgraph:
     Returns : csrgraph
     """
     elist = pd.DataFrame(tuples)
-    return _from_df(elist, directed=directed)
+    return from_df(elist, directed=directed)

--- a/csrgraph/graph.py
+++ b/csrgraph/graph.py
@@ -509,6 +509,10 @@ def read_edgelist(f, directed=True, sep=r"\s+", header=None, keep_default_na=Fal
         f, sep=sep, header=header, 
         keep_default_na=keep_default_na, **readcsvkwargs
     )
+    return _from_df(elist, directed=directed)
+
+
+def _from_df(elist: pd.DataFrame, directed: bool = True) -> csrgraph:
     if len(elist.columns) == 2:
         elist.columns = ['src', 'dst']
         elist['weight'] = np.ones(elist.shape[0])

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -247,9 +247,7 @@ class TestFileInput(unittest.TestCase):
         name_dict = dict(zip(np.arange(N_NODES), new_names))
         for c in df.columns:
             df[c] = df[c].map(name_dict)
-        # Pass this new data to read_edgelist
-        data = io.StringIO(df.to_csv(index=False, header=False))
-        G = cg.read_edgelist(data, sep=',')
+        G = cg.from_df(df)
         # re-read original graph
         df2 = pd.read_csv(fname, sep="\t", header=None)
         # re-map IDs to string node names


### PR DESCRIPTION
This PR packages most of the functionality from `read_edgelist()` into a private function so it can be reused for other methods that construct pandas dataframes. This PR then adds a new function `from_tuples` to make it easier to generate a CSRGraph from tuples in memory